### PR TITLE
Update BookingRowValidator.cs

### DIFF
--- a/src/FluiTec.DatevSharp/Validation/BookingRowValidator.cs
+++ b/src/FluiTec.DatevSharp/Validation/BookingRowValidator.cs
@@ -57,7 +57,7 @@ namespace FluiTec.DatevSharp.Validation
             RuleFor(booking => booking)
                 .Must(b => b.AccountNumber.Length + b.ContraAccountNumber.Length <= impersonalAccountsLength * 2 + 1)
                 .WithMessage("Booking from one PersonalAccountNumber to another PersonalAccountNumber is forbidden!");
-            RuleFor(booking => booking.TaxKey).Length(1, 4);
+            RuleFor(booking => booking.TaxKey).Length(0, 4);
             RuleFor(booking => booking.Date).NotNull();
             RuleFor(booking => booking.DocumentField1).Length(0, 36);
             RuleFor(booking => booking.DocumentField2).Length(0, 12);


### PR DESCRIPTION
The TaxKey is an optional parameter. The Validator rule should check for a length between 0 and 4 characters, instead of 1 to 4.