### PR TITLE
Add [StringValue(null)] Undefined for not necessary Enums having StringValues

### DIFF
--- a/src/FluiTec.Datev.sln
+++ b/src/FluiTec.Datev.sln
@@ -16,7 +16,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluiTec.DatevSharp.VersionCoverageReport", "FluiTec.DatevSharp.VersionCoverageReport\FluiTec.DatevSharp.VersionCoverageReport.csproj", "{8480CA8F-315B-4175-B6D8-1A9E29878046}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FluiTec.DatevSharp.VersionCoverageReport", "FluiTec.DatevSharp.VersionCoverageReport\FluiTec.DatevSharp.VersionCoverageReport.csproj", "{8480CA8F-315B-4175-B6D8-1A9E29878046}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{8B4F1B21-92CC-4EA6-A9E4-8E80F324CE50}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluiTec.DatevSharp.EnumAnalyzer", "FluiTec.DatevSharp.EnumAnalyzer\FluiTec.DatevSharp.EnumAnalyzer.csproj", "{042BE2D7-1841-4C96-8675-C49FF8423EB0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -40,9 +44,17 @@ Global
 		{8480CA8F-315B-4175-B6D8-1A9E29878046}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8480CA8F-315B-4175-B6D8-1A9E29878046}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8480CA8F-315B-4175-B6D8-1A9E29878046}.Release|Any CPU.Build.0 = Release|Any CPU
+		{042BE2D7-1841-4C96-8675-C49FF8423EB0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{042BE2D7-1841-4C96-8675-C49FF8423EB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{042BE2D7-1841-4C96-8675-C49FF8423EB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{042BE2D7-1841-4C96-8675-C49FF8423EB0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{8480CA8F-315B-4175-B6D8-1A9E29878046} = {8B4F1B21-92CC-4EA6-A9E4-8E80F324CE50}
+		{042BE2D7-1841-4C96-8675-C49FF8423EB0} = {8B4F1B21-92CC-4EA6-A9E4-8E80F324CE50}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BFAE6A80-0959-499D-B40F-05DB56BCA946}

--- a/src/FluiTec.DatevSharp.EnumAnalyzer/FluiTec.DatevSharp.EnumAnalyzer.csproj
+++ b/src/FluiTec.DatevSharp.EnumAnalyzer/FluiTec.DatevSharp.EnumAnalyzer.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FluiTec.DatevSharp\FluiTec.DatevSharp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/FluiTec.DatevSharp.EnumAnalyzer/Program.cs
+++ b/src/FluiTec.DatevSharp.EnumAnalyzer/Program.cs
@@ -1,0 +1,72 @@
+﻿using System.Reflection;
+using FluiTec.DatevSharp.Helpers;
+using FluiTec.DatevSharp.Rows.Enums;
+
+namespace FluiTec.DatevSharp.EnumAnalyzer;
+
+internal class Program
+{
+    static List<string> enumNames = new();
+
+    private static void Main(string[] args)
+    {
+        Console.WriteLine("Output to be excepted: NO OUTPUT");
+        Console.WriteLine("If any name of an enum appears here - please add Value 'Undefined' as with [StringValue(null)]");
+        var categories = new[]
+        {
+            DataCategories.Instance.AddressCategory,
+            DataCategories.Instance.TermsOfPaymentCategory,
+            DataCategories.Instance.BookingCategory
+        };
+
+        foreach (var cat in categories)
+        {
+            Console.WriteLine($"Add enums of {cat.Name}");
+            DumpEnums(cat);
+        }
+
+        foreach (var name in enumNames.Distinct())
+            Console.WriteLine(name);
+
+        Console.WriteLine("Done");
+    }
+
+    private static void DumpEnums(DataCategory category)
+    {
+        foreach (var version in category.Versions)
+        {
+            foreach (var field in version.FormatDescription.Fields.OrderBy(f => f.OrdinalNumber))
+            {
+                var label = !string.IsNullOrWhiteSpace(field.LabelAlias) ? field.LabelAlias : field.Label;
+                var map = category.RowType.GetDatevMetadata().GetMap();
+                var memberMap = map.FindByOrdinalNumber(field.OrdinalNumber);
+                
+                if (memberMap == null) continue;
+                if (memberMap.Member.MemberType != MemberTypes.Property) continue;
+                var propertyInfo = (PropertyInfo)memberMap.Member;
+                var memberType = propertyInfo.PropertyType;
+                
+                if (memberType.IsEnum && field.Necessary == 0)
+                {
+                    var values = Enum.GetValues(memberType);
+                    var hasUndefined = false;
+                    var hasStringValues = false;
+                    foreach (var value in values)
+                    {
+                        var name = Enum.GetName(memberType, value);
+                        var sv = EnumHelper.GetStringValue(memberType, name);
+                        if (name == "Undefined")
+                            hasUndefined = true;
+                        else if (sv != null)
+                            hasStringValues = true;
+                    }
+
+                    if (!hasUndefined && hasStringValues)
+                    {
+                        enumNames.Add(memberType.FullName!);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/FluiTec.DatevSharp/FluiTec.DatevSharp.csproj
+++ b/src/FluiTec.DatevSharp/FluiTec.DatevSharp.csproj
@@ -12,6 +12,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Achim Schnell</Authors>
     <Company>Achim Schnell</Company>
+	<LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FluiTec.DatevSharp/Helpers/EnumHelper.cs
+++ b/src/FluiTec.DatevSharp/Helpers/EnumHelper.cs
@@ -19,11 +19,11 @@ namespace FluiTec.DatevSharp.Helpers
         /// <returns>
         ///     The string value.
         /// </returns>
-        private static string GetStringValue(Type enumType, string fieldName)
+        public static string GetStringValue(Type enumType, string fieldName)
         {
             var fieldInfo = enumType.GetField(fieldName);
-            return fieldInfo.GetCustomAttributes(typeof(StringValueAttribute), false)
-                is StringValueAttribute[] attrs && attrs.Length > 0
+            return fieldInfo?.GetCustomAttributes(typeof(StringValueAttribute), false)
+                is StringValueAttribute[] { Length: > 0 } attrs
                 ? attrs[0].Value
                 : null;
         }

--- a/src/FluiTec.DatevSharp/Rows/Enums/BookingType.cs
+++ b/src/FluiTec.DatevSharp/Rows/Enums/BookingType.cs
@@ -7,6 +7,7 @@ namespace FluiTec.DatevSharp.Rows.Enums
     /// </summary>
     public enum BookingType
     {
+        [StringValue(null)] Undefined,
         [StringValue("AA")] RequestedCommission,
         [StringValue("AG")] ReceivedCommission,
         [StringValue("AV")] ReceivedObligation,

--- a/src/FluiTec.DatevSharp/Rows/Enums/PostalAddressType.cs
+++ b/src/FluiTec.DatevSharp/Rows/Enums/PostalAddressType.cs
@@ -7,6 +7,7 @@ namespace FluiTec.DatevSharp.Rows.Enums
     /// </summary>
     public enum PostalAddressType
     {
+        [StringValue(null)] Undefined,
         [StringValue("STR")] Street,
         [StringValue("PF")] PostBox,
         [StringValue("GK")] MajorCustomer

--- a/src/FluiTec.DatevSharp/Rows/Enums/TaxationType.cs
+++ b/src/FluiTec.DatevSharp/Rows/Enums/TaxationType.cs
@@ -7,6 +7,7 @@ namespace FluiTec.DatevSharp.Rows.Enums
     /// </summary>
     public enum TaxationType
     {
+        [StringValue(null)] Undefined,
         [StringValue("I")] Actual,
         [StringValue("K")] None,
         [StringValue("P")] Flat,


### PR DESCRIPTION
Added a simple tool to find Enums that are:
a) not necessary according to the format specification
b) have StringValues applied

Rule b) is applied since the C#'s default value for any enum should be 0. And as datev treats every 0 as an empty value - the result should be the same.

Thus added [StringValue(null)] Undefined to the following enums:
- PostalAddressType
- TaxationType
- BookingType